### PR TITLE
Don't include Log4J (v1) transitively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
       <groupId>com.joptimizer</groupId>
       <artifactId>joptimizer</artifactId>
       <version>${joptimizer.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
I noticed that logtool-examples was still using Log4J v1. That shouldn't be possible, but it turns out it got that dependency transitively via the `joptimizer` module in customer-modules.